### PR TITLE
Allow private actions and reduce downloads

### DIFF
--- a/.github/workflows/magisk.yml
+++ b/.github/workflows/magisk.yml
@@ -96,10 +96,16 @@ jobs:
     strategy:
       matrix: ${{fromJson(needs.matrix.outputs.matrix)}}
     steps:
+      - name: Clone repository
+        uses: actions/checkout@v3.0.2
+      - name: Create archive from repository
+        run: |
+          sudo tar -cf /tmp/repo.tar .
+          sudo rm -rf *
       - name: Dependencies
         run: |
           sudo apt-get update && sudo apt-get install setools lzip wine winetricks patchelf
-          wget -qO- "$GITHUB_SERVER_URL/$GITHUB_REPOSITORY/archive/$GITHUB_REF.tar.gz" | sudo tar --wildcards -zxvf- -C ~ --strip-component=2 '*/wine/*' '*/linker/*' '*/xml/*'
+          sudo tar --wildcards -xf /tmp/repo.tar -C ~ --strip-component=2 '*/wine/*' '*/linker/*' '*/xml/*'
           winetricks msxml6
       - name: Download WSA
         shell: python
@@ -316,7 +322,7 @@ jobs:
         if: ${{ github.event.inputs.gapps_variant != 'none' && github.event.inputs.gapps_variant != '' }}
         run: |
           mkdir gapps
-          unzip -p gapps.zip {Core,GApps}/'*.lz' | tar --lzip -C gapps -xvf - -i --strip-components=2 --exclude='setupwizardtablet-x86_64' --exclude='packageinstallergoogle-all' --exclude='speech-common' --exclude='markup-lib-arm' --exclude='markup-lib-arm64' --exclude='markup-all' --exclude='setupwizarddefault-x86_64' --exclude='pixellauncher-all' --exclude='pixellauncher-common'
+          unzip -p gapps.zip {Core,GApps}/'*.lz' | tar --lzip -C gapps -xf - -i --strip-components=2 --exclude='setupwizardtablet-x86_64' --exclude='packageinstallergoogle-all' --exclude='speech-common' --exclude='markup-lib-arm' --exclude='markup-lib-arm64' --exclude='markup-all' --exclude='setupwizarddefault-x86_64' --exclude='pixellauncher-all' --exclude='pixellauncher-common'
 
       - name: Expand images
         run: |
@@ -458,14 +464,14 @@ jobs:
           sed -i -zE "s/<Resources.*Resources>/<Resources>\n$(cat xml/* | grep -Po '<Resource [^>]*/>' | sed ':a;N;$!ba;s/\n/\\n/g' | sed 's/\$/\\$/g' | sed 's/\//\\\//g')\n<\/Resources>/g" ${{ matrix.arch }}/AppxManifest.xml
       - name: Add extra packages
         run: |
-          wget -qO- "$GITHUB_SERVER_URL/$GITHUB_REPOSITORY/archive/$GITHUB_REF.tar.gz" | sudo tar --wildcards -zxvf- --strip-component=2 '*/${{ matrix.arch }}/system/*'
+          sudo tar --wildcards -xf /tmp/repo.tar --strip-component=2 '*/${{ matrix.arch }}/system/*'
           sudo find system/system/priv-app -type d -exec chmod 0755 {} \;
           sudo find system/system/priv-app -type f -exec chmod 0644 {} \;
           sudo find system/system/priv-app -exec chcon --reference=system/system/priv-app {} \;
       - name: Integrate GApps
         if: ${{ github.event.inputs.gapps_variant != 'none' && github.event.inputs.gapps_variant != '' }}
         run: |
-          wget -qO- "$GITHUB_SERVER_URL/$GITHUB_REPOSITORY/archive/$GITHUB_REF.tar.gz" | sudo tar --wildcards -zxvf- --strip-component=2 '*/${{ matrix.arch }}/gapps/*'
+          sudo tar --wildcards -xf /tmp/repo.tar --strip-component=2 '*/${{ matrix.arch }}/gapps/*'
           shopt -s extglob
           sudo cp -vr gapps/!(product) system/system
           sudo cp -vr gapps/product/* system/product/


### PR DESCRIPTION
* Download the repo using actions/checkout (so the latest ref is always referenced, without the need of hacky env vars). The .tar file is created after the repo is cloned, so it can be reused for every step (instead of wget'ting it at every step). This should reduce the possibility of timeouts or other network errors.

* Action can now run on private repos

* Reduced verbosity of tar: The -v argument is not that necessary in this kind of context, where the contents of the archive will always be predictable.